### PR TITLE
Including Makefile in final container

### DIFF
--- a/C2_Profiles/basic_logger/Dockerfile
+++ b/C2_Profiles/basic_logger/Dockerfile
@@ -12,6 +12,8 @@ RUN apk add --update make
 
 COPY --from=builder /main /main
 
+COPY Makefile /Mythic/Makefile
+
 WORKDIR /Mythic/
 
 CMD make run


### PR DESCRIPTION
The alpine instance has no make target, as the Makefile is copied to the golang builder container but not the final alpine instance.
``` 
#> docker logs basic_logger
 make: *** No rule to make target 'run'.  Stop.
```

It may be baked into the image, but failed when I built locally via *_USE_BUILD_CONTEXT.

Thanks!